### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock


### PR DESCRIPTION
Surprised to notice that there was no .gitignore in the repository yet. It should be automatically created when starting a new Cargo project using `cargo init`.
This ought to do it.