### PR TITLE
Remove "homepage" from manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "parsnip"
 version = "0.2.2"
 authors = ["Erik A. Partridge <erik.partridge@mail.mcgill.ca>"]
 license = "MIT"
-homepage = "https://github.com/ErikPartridge/parsnip"
 repository = "https://github.com/ErikPartridge/parsnip"
 categories = ["science"]
 description = "Data science metrics (presently categorical only) for Rust."


### PR DESCRIPTION
The "homepage" attribute is used for dedicated websites, and should not point to the repository (there is already another field for that one). Please see the [C-METADATA](https://rust-lang-nursery.github.io/api-guidelines/documentation.html#c-metadata) guideline for more information.