### PR TITLE
Generic parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ is-it-maintained-open-issues = { repository = "ErikPartridge/parsnip" }
 travis-ci = { repository = "ErikPartridge/parsnip", branch = "master" }
 
 [dependencies]
+num = "0.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ is-it-maintained-open-issues = { repository = "ErikPartridge/parsnip" }
 travis-ci = { repository = "ErikPartridge/parsnip", branch = "master" }
 
 [dependencies]
-num = "0.2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,18 +36,18 @@ pub fn gini<T: Unsigned + ToPrimitive>(data: &[T]) -> f32 {
 /// Returns a float where 1.0 is a perfectly accurate dataset
 /// ```
 /// use parsnip::categorical_accuracy;
-/// let pred = vec![0, 0, 0 , 1, 2];
-/// let actual = vec![1, 1, 1, 1, 2];
+/// let pred : Vec<u16> = vec![0, 0, 0 , 1, 2];
+/// let actual : Vec<u16> = vec![1, 1, 1, 1, 2];
 /// assert_eq!(categorical_accuracy(&pred, &actual), 0.4);
 /// ```
-pub fn categorical_accuracy(pred: &[u64], actual: &[u64]) -> f32 {
+pub fn categorical_accuracy<T: Unsigned + ToPrimitive>(pred: &[T], actual: &[T]) -> f32 {
     assert_eq!(pred.len(), actual.len());
     let bools =  pred.iter().zip(actual).map(|(x,y)| x == y);
     let truthy : Vec<bool> =  bools.filter(|b| *b).collect();
     return truthy.len() as f32 / pred.len() as f32;
 }
 
-fn class_precision(pred: &[u64], actual: &[u64], class: u64) -> f32 {
+fn class_precision<T: Unsigned + ToPrimitive>(pred: &[T], actual: &[T], class: T) -> f32 {
     assert_eq!(pred.len(), actual.len());
     let true_positives_map = pred.iter().zip(actual).map(|(p, a)| p == a && *p == class);
     let true_positives = true_positives_map.filter(|b| *b).count() as f32;
@@ -296,15 +296,15 @@ mod tests {
 
     #[test]
     fn test_categorical_accuracy() {
-        let pred = vec![0, 1, 0, 1, 0, 1];
-        let real = vec![0, 0, 0, 0, 1, 0];
+        let pred : Vec<u16> = vec![0, 1, 0, 1, 0, 1];
+        let real : Vec<u16> = vec![0, 0, 0, 0, 1, 0];
         assert_eq!(0.33333334, categorical_accuracy(&pred, &real));
     }
 
     #[test]
     fn test_class_precision() {
-        let actual = vec![0, 1, 2, 0, 1, 2];
-        let pred = vec![0, 2, 1, 0, 0, 1];
+        let actual = vec![0_u16, 1, 2, 0, 1, 2];
+        let pred : Vec<u16> = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(0.6666667, class_precision(&pred, &actual, 0));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ pub fn gini<T: Unsigned + ToPrimitive>(data: &[T]) -> f32 {
     let len = data.len() as f32;
     let mut count = HashMap::new();
     for ref value in data {
-        *count.entry(value.to_usize().unwrap()).or_insert(0) += 1;
+        *count.entry(value.to_u128().unwrap()).or_insert(0) += 1;
     }
-    let counts: Vec<usize> = count.into_iter().map(|(_, c)| c).collect();
+    let counts: Vec<u128> = count.into_iter().map(|(_, c)| c).collect();
     let indiv : Vec<f32> = counts.iter().map(|x| p_squared(*x, len)).collect();
     let sum : f32 = indiv.iter().sum();
     1.0 - sum
@@ -65,9 +65,9 @@ fn weighted_precision<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actua
     classes.sort();
     classes.dedup();
     for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), actual.iter().filter(|a| *a == value).count() as f32 / actual.len() as f32);
+        class_weights.insert(value.to_u128().unwrap(), actual.iter().filter(|a| *a == value).count() as f32 / actual.len() as f32);
     }
-    return classes.iter().map(|c| class_precision(pred, actual, (**c).clone()) * class_weights.get(&c.to_usize().unwrap()).unwrap()).sum();
+    return classes.iter().map(|c| class_precision(pred, actual, (**c).clone()) * class_weights.get(&c.to_u128().unwrap()).unwrap()).sum();
 }
 
 fn macro_precision<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
@@ -77,7 +77,7 @@ fn macro_precision<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: 
     classes.sort();
     classes.dedup();
     for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), 1.0 / actual.len() as f32);
+        class_weights.insert(value.to_u128().unwrap(), 1.0 / actual.len() as f32);
     }
     return classes.iter().map(|c| class_precision(pred, actual, (**c).clone()) / classes.len() as f32).sum();
 }
@@ -124,9 +124,9 @@ fn weighted_recall<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: 
     classes.sort();
     classes.dedup();
     for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), actual.iter().filter(|a| **a == *value).count() as f32 / actual.len() as f32);
+        class_weights.insert(value.to_u128().unwrap(), actual.iter().filter(|a| **a == *value).count() as f32 / actual.len() as f32);
     }
-    return classes.iter().map(|c| class_recall(pred, actual, (*c).clone()) * class_weights.get(&c.to_usize().unwrap()).unwrap()).sum();
+    return classes.iter().map(|c| class_recall(pred, actual, (*c).clone()) * class_weights.get(&c.to_u128().unwrap()).unwrap()).sum();
 }
 
 fn macro_recall<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
@@ -136,7 +136,7 @@ fn macro_recall<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T
     classes.sort();
     classes.dedup();
     for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), 1.0 / actual.len() as f32);
+        class_weights.insert(value.to_u128().unwrap(), 1.0 / actual.len() as f32);
     }
     return classes.iter().map(|c| class_recall(pred, actual, (*c).clone()) / classes.len() as f32).sum();
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
-use std::iter::FromIterator;
 
 /// Compute the gini impurity of a dataset.
 ///
@@ -80,7 +79,7 @@ where
     T: Hash,
 {
     assert_eq!(pred.len(), actual.len());
-    let classes: HashSet<_> = HashSet::from_iter(pred);
+    let classes: HashSet<_> = pred.into_iter().collect();
     let mut class_weights = HashMap::new();
     for value in &classes {
         class_weights.insert(
@@ -100,7 +99,7 @@ where
     T: Hash,
 {
     assert_eq!(pred.len(), actual.len());
-    let classes: HashSet<_> = HashSet::from_iter(pred);
+    let classes: HashSet<_> = pred.into_iter().collect();
     let mut class_weights = HashMap::new();
     for value in classes.clone() {
         class_weights.insert(value, 1.0 / actual.len() as f32);
@@ -163,7 +162,7 @@ where
     T: Hash,
 {
     assert_eq!(pred.len(), actual.len());
-    let classes: HashSet<_> = HashSet::from_iter(pred);
+    let classes: HashSet<_> = pred.into_iter().collect();
     let mut class_weights = HashMap::new();
     for value in &classes {
         class_weights.insert(
@@ -183,7 +182,7 @@ where
     T: Hash,
 {
     assert_eq!(pred.len(), actual.len());
-    let classes: HashSet<_> = HashSet::from_iter(pred);
+    let classes: HashSet<_> = pred.into_iter().collect();
     classes
         .iter()
         .map(|c| class_recall(pred, actual, *c) / classes.len() as f32)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,38 +1,39 @@
-use num::cast::ToPrimitive;
-use std::collections::HashMap;
-extern crate num;
-use num::Unsigned;
+use std::collections::BTreeMap;
 
-/// Compute the gini impurity of a dataset. 
-/// 
+/// Compute the gini impurity of a dataset.
+///
 /// Returns a float, 0 representing a perfectly pure dataset. Normal distribution: ~0.33
-/// 
+///
 /// By default, any empty dataset will return a gini of 1.0. This may be unexpected behaviour.
 /// ```
 /// use parsnip::gini;
 /// assert_eq!(gini(&vec![0_usize, 0, 0, 1]), 0.375);
 /// ```
-pub fn gini<T: Unsigned + ToPrimitive>(data: &[T]) -> f32 {
+pub fn gini<T>(data: &[T]) -> f32
+where
+    T: Eq,
+    T: Ord,
+{
     if data.len() == 0 {
         return 1.0;
-    } 
+    }
     fn p_squared(count: usize, len: f32) -> f32 {
         let p = count as f32 / len;
         return p * p;
     }
     let len = data.len() as f32;
-    let mut count = HashMap::new();
-    for ref value in data {
-        *count.entry(value.to_usize().unwrap()).or_insert(0) += 1;
+    let mut count = BTreeMap::new();
+    for value in data.iter() {
+        *count.entry(value).or_insert(0) += 1;
     }
     let counts: Vec<usize> = count.into_iter().map(|(_, c)| c).collect();
-    let indiv : Vec<f32> = counts.iter().map(|x| p_squared(*x, len)).collect();
-    let sum : f32 = indiv.iter().sum();
+    let indiv: Vec<f32> = counts.iter().map(|x| p_squared(*x, len)).collect();
+    let sum: f32 = indiv.iter().sum();
     return 1.0 - sum;
 }
 
 /// The categorical accuracy of a dataset
-/// 
+///
 /// Returns a float where 1.0 is a perfectly accurate dataset
 /// ```
 /// use parsnip::categorical_accuracy;
@@ -40,252 +41,373 @@ pub fn gini<T: Unsigned + ToPrimitive>(data: &[T]) -> f32 {
 /// let actual : Vec<u16> = vec![1, 1, 1, 1, 2];
 /// assert_eq!(categorical_accuracy(&pred, &actual), 0.4);
 /// ```
-pub fn categorical_accuracy<T: Unsigned + ToPrimitive>(pred: &[T], actual: &[T]) -> f32 {
+pub fn categorical_accuracy<T>(pred: &[T], actual: &[T]) -> f32
+where
+    T: Eq,
+{
     assert_eq!(pred.len(), actual.len());
-    let truthy =  pred.iter().zip(actual).filter(|(x,y)| x == y).count();
+    let truthy = pred.iter().zip(actual).filter(|(x, y)| x == y).count();
     return truthy as f32 / pred.len() as f32;
 }
 
-fn class_precision<T: Unsigned + ToPrimitive>(pred: &[T], actual: &[T], class: T) -> f32 {
+
+fn class_precision<T>(pred: &[T], actual: &[T], class: &T) -> f32
+where
+    T: Eq,
+{
     assert_eq!(pred.len(), actual.len());
     //First, get the map of all true positives
-    let true_positives = pred.iter().zip(actual).filter(|(p, a)| p == a && **p == class).count() as f32;
-    let all_positives = pred.iter().filter(|p| **p == class).count() as f32;
+    let true_positives = pred
+        .iter()
+        .zip(actual)
+        .filter(|(p, a)| p == a && **p == *class)
+        .count() as f32;
+    let all_positives = pred.iter().filter(|p| **p == *class).count() as f32;
     if all_positives == 0.0 {
         return 0.0;
     }
     return true_positives / all_positives;
 }
 
-fn weighted_precision<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
+
+fn weighted_precision<T>(pred: &[T], actual: &[T]) -> f32 
+where
+    T: Eq,
+    T: Ord
+{
     assert_eq!(pred.len(), actual.len());
-    let mut classes : Vec<&T> = pred.into_iter().collect();
-    let mut class_weights = HashMap::new();
+    let mut classes: Vec<&T> = pred.into_iter().collect();
+    let mut class_weights = BTreeMap::new();
     classes.sort();
     classes.dedup();
     for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), actual.iter().filter(|a| *a == value).count() as f32 / actual.len() as f32);
+        class_weights.insert(
+            value,
+            actual.iter().filter(|a| *a == value).count() as f32 / actual.len() as f32,
+        );
     }
-    return classes.iter().map(|c| class_precision(pred, actual, (**c).clone()) * class_weights.get(&c.to_usize().unwrap()).unwrap()).sum();
+    return classes
+        .iter()
+        .map(|c| {
+            class_precision(pred, actual, *c)
+                * class_weights.get(c).unwrap()
+        }).sum();
 }
 
-fn macro_precision<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
+
+fn macro_precision<T>(pred: &[T], actual: &[T]) -> f32
+where
+    T: Eq,
+    T: Ord,
+{
     assert_eq!(pred.len(), actual.len());
-    let mut classes : Vec<&T> = pred.into_iter().collect();
-    let mut class_weights = HashMap::new();
+    let mut classes: Vec<&T> = pred.into_iter().collect();
+    let mut class_weights = BTreeMap::new();
     classes.sort();
     classes.dedup();
     for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), 1.0 / actual.len() as f32);
+        class_weights.insert(value, 1.0 / actual.len() as f32);
     }
-    return classes.iter().map(|c| class_precision(pred, actual, (**c).clone()) / classes.len() as f32).sum();
+    return classes
+        .iter()
+        .map(|c| class_precision(pred, actual, *c) / classes.len() as f32)
+        .sum();
 }
+
 
 /// The precision of a dataset
-/// 
+///
 /// Returns a float where a 1.0 is a perfectly precise result set
-/// 
+///
 /// Supports macro and weighted averages
 /// ```
 /// use parsnip::precision;
-/// 
+///
 /// let actual = vec![0_u8, 1, 2, 0, 1, 2];
 /// let pred = vec![0_u8, 2, 1, 0, 0, 1];
-/// 
+///
 /// assert_eq!(precision(&pred, &actual, Some("macro".to_string())), 0.22222222);
 /// ```
-pub fn precision<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T], average: Option<String>) -> f32 {
+pub fn precision<T>(
+    pred: &[T],
+    actual: &[T],
+    average: Option<String>,
+) -> f32 where
+    T: Eq,
+    T: Ord, 
+{
     match average {
         None => return macro_precision(pred, actual),
         Some(string) => match string.as_ref() {
             "macro" => return macro_precision(pred, actual),
             "weighted" => return weighted_precision(pred, actual),
-            _ => panic!("invalid averaging type")
-        }
+            _ => panic!("invalid averaging type"),
+        },
     }
 }
 
-fn class_recall<T: Unsigned>(pred: &[T], actual: &[T], class: T) -> f32 {
+
+fn class_recall<T>(pred: &[T], actual: &[T], class: &T) -> f32 where
+    T: Eq,
+{
     assert_eq!(pred.len(), actual.len());
-    let true_positives = pred.iter().zip(actual).filter(|(p, a)| p == a && **a == class).count() as f32;
-    let tp_fn = actual.iter().filter(|a| **a == class).count() as f32;
+    let true_positives = pred
+        .iter()
+        .zip(actual)
+        .filter(|(p, a)| p == a && **a == *class)
+        .count() as f32;
+    let tp_fn = actual.iter().filter(|a| **a == *class).count() as f32;
     if tp_fn == 0.0 {
         return 0.0;
     }
     return true_positives / tp_fn;
 }
 
-fn weighted_recall<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
+
+fn weighted_recall<T>(pred: &[T], actual: &[T]) -> f32 where
+    T: Eq,
+    T: Ord,
+{
     assert_eq!(pred.len(), actual.len());
-    let mut classes : Vec<&T> = pred.into_iter().collect();
-    let mut class_weights = HashMap::new();
+    let mut classes: Vec<&T> = pred.into_iter().collect();
+    let mut class_weights = BTreeMap::new();
     classes.sort();
     classes.dedup();
     for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), actual.iter().filter(|a| **a == *value).count() as f32 / actual.len() as f32);
+        class_weights.insert(
+            value,
+            actual.iter().filter(|a| **a == *value).count() as f32 / actual.len() as f32,
+        );
     }
-    return classes.iter().map(|c| class_recall(pred, actual, (*c).clone()) * class_weights.get(&c.to_usize().unwrap()).unwrap()).sum();
+    return classes
+        .iter()
+        .map(|c| {
+            class_recall(pred, actual, *c)
+                * class_weights.get(*c).unwrap()
+        }).sum();
 }
 
-fn macro_recall<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
+
+fn macro_recall<T>(pred: &[T], actual: &[T]) -> f32 
+where
+    T: Eq,
+    T: Ord,
+{
     assert_eq!(pred.len(), actual.len());
-    let mut classes : Vec<&T> = pred.into_iter().collect();
-    let mut class_weights = HashMap::new();
+    let mut classes: Vec<&T> = pred.into_iter().collect();
     classes.sort();
     classes.dedup();
-    for value in classes.clone() {
-        class_weights.insert(value.to_usize().unwrap(), 1.0 / actual.len() as f32);
-    }
-    return classes.iter().map(|c| class_recall(pred, actual, (*c).clone()) / classes.len() as f32).sum();
+    return classes
+        .iter()
+        .map(|c| class_recall(pred, actual, *c) / classes.len() as f32)
+        .sum();
 }
+
 
 /// The recall of a dataset
-/// 
+///
 /// Returns a float where a 1.0 is a perfectly recalled result set
-/// 
+///
 /// Supports macro and weighted averages
 /// ```
 /// use parsnip::recall;
-/// 
+///
 /// let actual = vec![0_u8, 1, 2, 0, 1, 2];
 /// let pred = vec![0_u8, 2, 1, 0, 0, 1];
-/// 
+///
 /// assert_eq!(recall(&pred, &actual, Some("macro".to_string())), 0.333333334);
 /// ```
-pub fn recall<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T], average: Option<String>) -> f32 {
+pub fn recall<T>(
+    pred: &[T],
+    actual: &[T],
+    average: Option<String>,
+) -> f32 
+where
+    T: Eq,
+    T: Ord,
+{
     match average {
         None => return macro_recall(pred, actual),
         Some(string) => match string.as_ref() {
             "macro" => return macro_recall(pred, actual),
             "weighted" => return weighted_recall(pred, actual),
-            _ => panic!("invalid averaging type")
-        }
+            _ => panic!("invalid averaging type"),
+        },
     }
 }
 
-fn macro_f1<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
+
+fn macro_f1<T>(pred: &[T], actual: &[T]) -> f32 
+where
+    T: Eq,
+    T: Ord,
+{
     let recall = macro_recall(pred, actual);
     let precision = macro_precision(pred, actual);
     return 2.0 * (recall * precision) / (recall + precision);
 }
 
-fn weighted_f1<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T]) -> f32 {
+#[cfg(not(any(feature = "use_ndarray")))]
+fn weighted_f1<T>(pred: &[T], actual: &[T]) -> f32
+where
+    T: Eq,
+    T: Ord,
+{
     let recall = weighted_recall(pred, actual);
     let precision = weighted_precision(pred, actual);
     return 2.0 * (recall * precision) / (recall + precision);
-
 }
 
+
 /// The f1 score of a dataset
-/// 
+///
 /// Returns an f1 score where 1 is perfect and 0 is atrocious.
-/// 
+///
 /// Supports macro and weighted averages
 /// ```
 /// use parsnip::f1_score;
-/// 
+///
 /// let actual = vec![0_u8, 1, 2, 0, 1, 2];
 /// let pred = vec![0_u8, 2, 1, 0, 0, 1];
-/// 
+///
 /// assert_eq!(f1_score(&pred, &actual, Some("macro".to_string())), 0.26666665);
 /// assert_eq!(f1_score(&pred, &actual, Some("weighted".to_string())), 0.26666668);
 /// ```
-pub fn f1_score<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T], average: Option<String>) -> f32 {
+pub fn f1_score<T>(
+    pred: &[T],
+    actual: &[T],
+    average: Option<String>,
+) -> f32 
+where
+    T: Eq,
+    T: Ord,
+{
     match average {
         None => return macro_f1(pred, actual),
         Some(string) => match string.as_ref() {
             "macro" => return macro_f1(pred, actual),
             "weighted" => return weighted_f1(pred, actual),
-            _ => panic!("invalid averaging type")
-        }
+            _ => panic!("invalid averaging type"),
+        },
     }
 }
 
+
 /// The hamming loss of a dataset
-/// 
+///
 /// Returns the hamming loss which is the percentage of items which are misclassified [0, 1]
-/// 
+///
 /// Supports macro and weighted averages
 /// ```
 /// use parsnip::hamming_loss;
-/// 
+///
 /// let actual = vec![0_u8, 1, 2, 0, 0];
 /// let pred = vec![0_u8, 2, 1, 0, 1];
-/// 
+///
 /// assert_eq!(hamming_loss(&pred, &actual), 0.6);
 /// ```
-pub fn hamming_loss<T: Unsigned + ToPrimitive>(pred: &[T], actual: &[T]) -> f32 {
+pub fn hamming_loss<T>(pred: &[T], actual: &[T]) -> f32
+where
+    T: Eq,
+{
     return 1.0 - categorical_accuracy(pred, actual);
 }
 
-fn macro_fbeta_score<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T], beta: f32) -> f32 {
+
+fn macro_fbeta_score<T>(
+    pred: &[T],
+    actual: &[T],
+    beta: f32,
+) -> f32
+where
+    T: Eq,
+    T: Ord,
+{
     let precision = macro_precision(pred, actual);
     let recall = macro_recall(pred, actual);
-    let top = (1.0 + beta * beta)  * (recall * precision);
+    let top = (1.0 + beta * beta) * (recall * precision);
     let bottom = (beta * beta * precision) + recall;
     return top / bottom;
 }
 
-fn weighted_fbeta_score<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T], beta: f32) -> f32 {
+fn weighted_fbeta_score<T>(
+    pred: &[T],
+    actual: &[T],
+    beta: f32,
+) -> f32 
+where
+    T: Eq,
+    T: Ord,
+{
     let precision = weighted_precision(pred, actual);
     let recall = weighted_recall(pred, actual);
-    let top = (1.0 + beta * beta)  * (recall * precision);
+    let top = (1.0 + beta * beta) * (recall * precision);
     let bottom = (beta * beta * precision) + recall;
     return top / bottom;
 }
 
 /// The fbeta of a dataset
-/// 
+///
 /// Returns the fbeta score [0, 1]
-/// 
+///
 /// Supports macro and weighted averages
 /// ```
 /// use parsnip::fbeta_score;
-/// 
+///
 /// let actual = vec![0_u8, 1, 2, 0, 1, 2];
 /// let pred = vec![0_u8, 2, 1, 0, 0, 1];
-/// 
+///
 /// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("macro".to_string())), 0.23809524);
 /// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("weighted".to_string())), 0.23809527);
 /// ```
-pub fn fbeta_score<T: Unsigned + ToPrimitive + Ord + Clone>(pred: &[T], actual: &[T], beta: f32, average: Option<String>) -> f32 {
+pub fn fbeta_score<T>(
+    pred: &[T],
+    actual: &[T],
+    beta: f32,
+    average: Option<String>,
+) -> f32 
+where
+    T: Eq,
+    T: Ord,
+{
     match average {
         None => return macro_fbeta_score(pred, actual, beta),
         Some(string) => match string.as_ref() {
             "macro" => return macro_fbeta_score(pred, actual, beta),
             "weighted" => return weighted_fbeta_score(pred, actual, beta),
-            _ => panic!("invalid averaging type")
-        }
+            _ => panic!("invalid averaging type"),
+        },
     }
 }
 
 /// The jaccard similarity of a dataset
-/// 
+///
 /// Returns the jaccard similarity score which for our purposes is effectively categorical accuracy [0, 1]
-/// 
+///
 /// Supports macro and weighted averages
 /// ```
 /// use parsnip::jaccard_similiarity_score;
-/// 
-/// let actual = vec![0_u8, 2, 1, 3];
-/// let pred = vec![0_u8, 1, 2, 3];
-/// 
+///
+/// let actual = vec![0_i32, 2, 1, 3];
+/// let pred = vec![0_i32, 1, 2, 3];
+///
 /// assert_eq!(jaccard_similiarity_score(&pred, &actual), 0.5);
 /// ```
-pub fn jaccard_similiarity_score<T: Unsigned + ToPrimitive>(pred: &[T], actual: &[T]) -> f32 {
+pub fn jaccard_similiarity_score<T>(pred: &[T], actual: &[T]) -> f32
+where
+    T: Eq,
+{
     return categorical_accuracy(pred, actual);
 }
-
-
 
 #[cfg(test)]
 mod tests {
     use super::*;
     #[test]
     fn test_gini() {
-        let vec : Vec<usize> = vec![0, 0, 0, 1];
+        let vec: Vec<usize> = vec![0, 0, 0, 1];
         assert_eq!(0.375, gini(&vec));
-        let v2 : Vec<usize> = vec![0, 0];
+        let v2: Vec<usize> = vec![0, 0];
         assert_eq!(0.0, gini(&v2));
         let mut v3: Vec<usize> = vec![0];
         v3.pop();
@@ -294,23 +416,23 @@ mod tests {
 
     #[test]
     fn test_categorical_accuracy() {
-        let pred : Vec<u16> = vec![0, 1, 0, 1, 0, 1];
-        let real : Vec<u16> = vec![0, 0, 0, 0, 1, 0];
+        let pred: Vec<u16> = vec![0, 1, 0, 1, 0, 1];
+        let real: Vec<u16> = vec![0, 0, 0, 0, 1, 0];
         assert_eq!(0.33333334, categorical_accuracy(&pred, &real));
     }
 
     #[test]
     fn test_class_precision() {
         let actual = vec![0_u16, 1, 2, 0, 1, 2];
-        let pred : Vec<u16> = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(0.6666667, class_precision(&pred, &actual, 0));
+        let pred: Vec<u16> = vec![0, 2, 1, 0, 0, 1];
+        assert_eq!(0.6666667, class_precision(&pred, &actual, &0));
     }
 
     #[test]
     fn test_class_recall() {
         let actual = vec![0_u16, 1, 2, 0, 0, 0];
         let pred = vec![0_u16, 2, 1, 0, 0, 1];
-        assert_eq!(0.75, class_recall(&pred, &actual, 0));
+        assert_eq!(0.75, class_recall(&pred, &actual, &0));
     }
 
     #[test]
@@ -327,14 +449,14 @@ mod tests {
         assert_eq!(0.22222222, macro_precision(&pred, &actual));
     }
 
-        #[test]
+    #[test]
     fn test_macro_recall() {
         let actual = vec![0_u8, 1, 2, 0, 1, 2];
         let pred = vec![0_u8, 2, 1, 0, 0, 1];
         assert_eq!(0.33333334, macro_recall(&pred, &actual));
     }
 
-        #[test]
+    #[test]
     fn test_weighted_recall() {
         let actual = vec![0_u8, 1, 2, 0, 1, 2];
         let pred = vec![0_u8, 2, 1, 0, 0, 1];
@@ -342,9 +464,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(any(feature = "use_ndarray")))]
     fn test_f1_score() {
         let actual = vec![0_u8, 1, 2, 0, 1, 2];
         let pred = vec![0_u8, 2, 1, 0, 0, 1];
-        assert_eq!(f1_score(&pred, &actual, Some("macro".to_string())), 0.26666665);
+        assert_eq!(
+            f1_score(&pred, &actual, Some("macro".to_string())),
+            0.26666665
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ where
     let counts: Vec<usize> = count.into_iter().map(|(_, c)| c).collect();
     let indiv: Vec<f32> = counts.iter().map(|x| p_squared(*x, len)).collect();
     let sum: f32 = indiv.iter().sum();
-    1.0 - sum;
+    return 1.0 - sum;
 }
 
 /// The categorical accuracy of a dataset
@@ -50,7 +50,6 @@ where
     return truthy as f32 / pred.len() as f32;
 }
 
-
 fn class_precision<T>(pred: &[T], actual: &[T], class: &T) -> f32
 where
     T: Eq,
@@ -70,11 +69,10 @@ where
     }
 }
 
-
-fn weighted_precision<T>(pred: &[T], actual: &[T]) -> f32 
+fn weighted_precision<T>(pred: &[T], actual: &[T]) -> f32
 where
     T: Eq,
-    T: Ord
+    T: Ord,
 {
     assert_eq!(pred.len(), actual.len());
     let mut classes: Vec<&T> = pred.into_iter().collect();
@@ -89,12 +87,9 @@ where
     }
     return classes
         .iter()
-        .map(|c| {
-            class_precision(pred, actual, *c)
-                * class_weights.get(c).unwrap()
-        }).sum();
+        .map(|c| class_precision(pred, actual, *c) * class_weights.get(c).unwrap())
+        .sum();
 }
-
 
 fn macro_precision<T>(pred: &[T], actual: &[T]) -> f32
 where
@@ -115,7 +110,6 @@ where
         .sum();
 }
 
-
 /// The precision of a dataset
 ///
 /// Returns a float where a 1.0 is a perfectly precise result set
@@ -129,13 +123,10 @@ where
 ///
 /// assert_eq!(precision(&pred, &actual, Some("macro".to_string())), 0.22222222);
 /// ```
-pub fn precision<T>(
-    pred: &[T],
-    actual: &[T],
-    average: Option<String>,
-) -> f32 where
+pub fn precision<T>(pred: &[T], actual: &[T], average: Option<String>) -> f32
+where
     T: Eq,
-    T: Ord, 
+    T: Ord,
 {
     match average {
         None => macro_precision(pred, actual),
@@ -147,8 +138,8 @@ pub fn precision<T>(
     }
 }
 
-
-fn class_recall<T>(pred: &[T], actual: &[T], class: &T) -> f32 where
+fn class_recall<T>(pred: &[T], actual: &[T], class: &T) -> f32
+where
     T: Eq,
 {
     assert_eq!(pred.len(), actual.len());
@@ -165,8 +156,8 @@ fn class_recall<T>(pred: &[T], actual: &[T], class: &T) -> f32 where
     }
 }
 
-
-fn weighted_recall<T>(pred: &[T], actual: &[T]) -> f32 where
+fn weighted_recall<T>(pred: &[T], actual: &[T]) -> f32
+where
     T: Eq,
     T: Ord,
 {
@@ -183,14 +174,11 @@ fn weighted_recall<T>(pred: &[T], actual: &[T]) -> f32 where
     }
     return classes
         .iter()
-        .map(|c| {
-            class_recall(pred, actual, *c)
-                * class_weights.get(*c).unwrap()
-        }).sum();
+        .map(|c| class_recall(pred, actual, *c) * class_weights.get(*c).unwrap())
+        .sum();
 }
 
-
-fn macro_recall<T>(pred: &[T], actual: &[T]) -> f32 
+fn macro_recall<T>(pred: &[T], actual: &[T]) -> f32
 where
     T: Eq,
     T: Ord,
@@ -205,7 +193,6 @@ where
         .sum();
 }
 
-
 /// The recall of a dataset
 ///
 /// Returns a float where a 1.0 is a perfectly recalled result set
@@ -219,11 +206,7 @@ where
 ///
 /// assert_eq!(recall(&pred, &actual, Some("macro".to_string())), 0.333333334);
 /// ```
-pub fn recall<T>(
-    pred: &[T],
-    actual: &[T],
-    average: Option<String>,
-) -> f32 
+pub fn recall<T>(pred: &[T], actual: &[T], average: Option<String>) -> f32
 where
     T: Eq,
     T: Ord,
@@ -238,8 +221,7 @@ where
     }
 }
 
-
-fn macro_f1<T>(pred: &[T], actual: &[T]) -> f32 
+fn macro_f1<T>(pred: &[T], actual: &[T]) -> f32
 where
     T: Eq,
     T: Ord,
@@ -260,7 +242,6 @@ where
     2.0 * (recall * precision) / (recall + precision)
 }
 
-
 /// The f1 score of a dataset
 ///
 /// Returns an f1 score where 1 is perfect and 0 is atrocious.
@@ -275,11 +256,7 @@ where
 /// assert_eq!(f1_score(&pred, &actual, Some("macro".to_string())), 0.26666665);
 /// assert_eq!(f1_score(&pred, &actual, Some("weighted".to_string())), 0.26666668);
 /// ```
-pub fn f1_score<T>(
-    pred: &[T],
-    actual: &[T],
-    average: Option<String>,
-) -> f32 
+pub fn f1_score<T>(pred: &[T], actual: &[T], average: Option<String>) -> f32
 where
     T: Eq,
     T: Ord,
@@ -293,7 +270,6 @@ where
         },
     }
 }
-
 
 /// The hamming loss of a dataset
 ///
@@ -315,12 +291,7 @@ where
     return 1.0 - categorical_accuracy(pred, actual);
 }
 
-
-fn macro_fbeta_score<T>(
-    pred: &[T],
-    actual: &[T],
-    beta: f32,
-) -> f32
+fn macro_fbeta_score<T>(pred: &[T], actual: &[T], beta: f32) -> f32
 where
     T: Eq,
     T: Ord,
@@ -332,11 +303,7 @@ where
     top / bottom
 }
 
-fn weighted_fbeta_score<T>(
-    pred: &[T],
-    actual: &[T],
-    beta: f32,
-) -> f32 
+fn weighted_fbeta_score<T>(pred: &[T], actual: &[T], beta: f32) -> f32
 where
     T: Eq,
     T: Ord,
@@ -362,12 +329,7 @@ where
 /// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("macro".to_string())), 0.23809524);
 /// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("weighted".to_string())), 0.23809527);
 /// ```
-pub fn fbeta_score<T>(
-    pred: &[T],
-    actual: &[T],
-    beta: f32,
-    average: Option<String>,
-) -> f32 
+pub fn fbeta_score<T>(pred: &[T], actual: &[T], beta: f32, average: Option<String>) -> f32
 where
     T: Eq,
     T: Ord,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::iter::FromIterator;
 /// By default, any empty dataset will return a gini of 1.0. This may be unexpected behaviour.
 /// ```
 /// use parsnip::gini;
-/// assert_eq!(gini(&vec![0_usize, 0, 0, 1]), 0.375);
+/// assert_eq!(gini(&vec![0, 0, 0, 1]), 0.375);
 /// ```
 pub fn gini<T>(data: &[T]) -> f32
 where
@@ -26,7 +26,7 @@ where
     }
     let len = data.len() as f32;
     let mut count = HashMap::new();
-    for value in data.iter() {
+    for value in data {
         *count.entry(value).or_insert(0) += 1;
     }
     let sum: f32 = count
@@ -42,8 +42,8 @@ where
 /// Returns a float where 1.0 is a perfectly accurate dataset
 /// ```
 /// use parsnip::categorical_accuracy;
-/// let pred : Vec<_> = vec![0, 0, 0 , 1, 2];
-/// let actual : Vec<_> = vec![1, 1, 1, 1, 2];
+/// let pred = vec![0, 0, 0 , 1, 2];
+/// let actual = vec![1, 1, 1, 1, 2];
 /// assert_eq!(categorical_accuracy(&pred, &actual), 0.4);
 /// ```
 pub fn categorical_accuracy<T>(pred: &[T], actual: &[T]) -> f32
@@ -119,8 +119,8 @@ where
 /// ```
 /// use parsnip::precision;
 ///
-/// let actual = vec![0_u8, 1, 2, 0, 1, 2];
-/// let pred = vec![0_u8, 2, 1, 0, 0, 1];
+/// let actual = vec![0, 1, 2, 0, 1, 2];
+/// let pred = vec![0, 2, 1, 0, 0, 1];
 ///
 /// assert_eq!(precision(&pred, &actual, Some("macro".to_string())), 0.22222222);
 /// ```
@@ -198,8 +198,8 @@ where
 /// ```
 /// use parsnip::recall;
 ///
-/// let actual = vec![0_u8, 1, 2, 0, 1, 2];
-/// let pred = vec![0_u8, 2, 1, 0, 0, 1];
+/// let actual = vec![0, 1, 2, 0, 1, 2];
+/// let pred = vec![0, 2, 1, 0, 0, 1];
 ///
 /// assert_eq!(recall(&pred, &actual, Some("macro".to_string())), 0.333333334);
 /// ```
@@ -246,8 +246,8 @@ where
 /// ```
 /// use parsnip::f1_score;
 ///
-/// let actual = vec![0_u8, 1, 2, 0, 1, 2];
-/// let pred = vec![0_u8, 2, 1, 0, 0, 1];
+/// let actual = vec![0, 1, 2, 0, 1, 2];
+/// let pred = vec![0, 2, 1, 0, 0, 1];
 ///
 /// assert_eq!(f1_score(&pred, &actual, Some("macro".to_string())), 0.26666665);
 /// assert_eq!(f1_score(&pred, &actual, Some("weighted".to_string())), 0.26666668);
@@ -275,8 +275,8 @@ where
 /// ```
 /// use parsnip::hamming_loss;
 ///
-/// let actual = vec![0_u8, 1, 2, 0, 0];
-/// let pred = vec![0_u8, 2, 1, 0, 1];
+/// let actual = vec![0, 1, 2, 0, 0];
+/// let pred = vec![0, 2, 1, 0, 1];
 ///
 /// assert_eq!(hamming_loss(&pred, &actual), 0.6);
 /// ```
@@ -319,8 +319,8 @@ where
 /// ```
 /// use parsnip::fbeta_score;
 ///
-/// let actual = vec![0_u8, 1, 2, 0, 1, 2];
-/// let pred = vec![0_u8, 2, 1, 0, 0, 1];
+/// let actual = vec![0, 1, 2, 0, 1, 2];
+/// let pred = vec![0, 2, 1, 0, 0, 1];
 ///
 /// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("macro".to_string())), 0.23809524);
 /// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("weighted".to_string())), 0.23809527);
@@ -348,8 +348,8 @@ where
 /// ```
 /// use parsnip::jaccard_similiarity_score;
 ///
-/// let actual = vec![0_i32, 2, 1, 3];
-/// let pred = vec![0_i32, 1, 2, 3];
+/// let actual = vec![0, 2, 1, 3];
+/// let pred = vec![0, 1, 2, 3];
 ///
 /// assert_eq!(jaccard_similiarity_score(&pred, &actual), 0.5);
 /// ```
@@ -365,68 +365,68 @@ mod tests {
     use super::*;
     #[test]
     fn test_gini() {
-        let vec: Vec<_> = vec![0, 0, 0, 1];
+        let vec = vec![0, 0, 0, 1];
         assert_eq!(0.375, gini(&vec));
-        let v2: Vec<_> = vec![0, 0];
+        let v2 = vec![0, 0];
         assert_eq!(0.0, gini(&v2));
-        let mut v3: Vec<_> = vec![0];
+        let mut v3 = vec![0];
         v3.pop();
         assert_eq!(1.0, gini(&v3));
     }
 
     #[test]
     fn test_categorical_accuracy() {
-        let pred: Vec<_> = vec![0, 1, 0, 1, 0, 1];
-        let real: Vec<_> = vec![0, 0, 0, 0, 1, 0];
+        let pred = vec![0, 1, 0, 1, 0, 1];
+        let real = vec![0, 0, 0, 0, 1, 0];
         assert_eq!(0.33333334, categorical_accuracy(&pred, &real));
     }
 
     #[test]
     fn test_class_precision() {
-        let actual = vec![0_u16, 1, 2, 0, 1, 2];
-        let pred: Vec<_> = vec![0, 2, 1, 0, 0, 1];
+        let actual = vec![0, 1, 2, 0, 1, 2];
+        let pred = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(0.6666667, class_precision(&pred, &actual, &0));
     }
 
     #[test]
     fn test_class_recall() {
-        let actual = vec![0_u16, 1, 2, 0, 0, 0];
-        let pred = vec![0_u16, 2, 1, 0, 0, 1];
+        let actual = vec![0, 1, 2, 0, 0, 0];
+        let pred = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(0.75, class_recall(&pred, &actual, &0));
     }
 
     #[test]
     fn test_weighted_precision() {
-        let actual = vec![0_u16, 1, 2, 0, 1, 2];
-        let pred = vec![0_u16, 2, 1, 0, 0, 1];
+        let actual = vec![0, 1, 2, 0, 1, 2];
+        let pred = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(0.22222224, weighted_precision(&pred, &actual));
     }
 
     #[test]
     fn test_macro_precision() {
-        let actual = vec![0_u16, 1, 2, 0, 1, 2];
-        let pred = vec![0_u16, 2, 1, 0, 0, 1];
+        let actual = vec![0, 1, 2, 0, 1, 2];
+        let pred = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(0.22222222, macro_precision(&pred, &actual));
     }
 
     #[test]
     fn test_macro_recall() {
-        let actual = vec![0_u8, 1, 2, 0, 1, 2];
-        let pred = vec![0_u8, 2, 1, 0, 0, 1];
+        let actual = vec![0, 1, 2, 0, 1, 2];
+        let pred = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(0.33333334, macro_recall(&pred, &actual));
     }
 
     #[test]
     fn test_weighted_recall() {
-        let actual = vec![0_u8, 1, 2, 0, 1, 2];
-        let pred = vec![0_u8, 2, 1, 0, 0, 1];
+        let actual = vec![0, 1, 2, 0, 1, 2];
+        let pred = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(0.333333334, weighted_recall(&pred, &actual));
     }
 
     #[test]
     fn test_f1_score() {
-        let actual = vec![0_u8, 1, 2, 0, 1, 2];
-        let pred = vec![0_u8, 2, 1, 0, 0, 1];
+        let actual = vec![0, 1, 2, 0, 1, 2];
+        let pred = vec![0, 2, 1, 0, 0, 1];
         assert_eq!(
             f1_score(&pred, &actual, Some("macro".to_string())),
             0.26666665

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
+use num::cast::ToPrimitive;
 use std::collections::HashMap;
+extern crate num;
 
+use num::Unsigned;
 /// Compute the gini impurity of a dataset. 
 /// 
 /// Returns a float, 0 representing a perfectly pure dataset. Normal distribution: ~0.33
@@ -7,9 +10,9 @@ use std::collections::HashMap;
 /// By default, any empty dataset will return a gini of 1.0. This may be unexpected behaviour.
 /// ```
 /// use parsnip::gini;
-/// assert_eq!(gini(&vec![0, 0, 0, 1]), 0.375);
+/// assert_eq!(gini(&vec![0_usize, 0, 0, 1]), 0.375);
 /// ```
-pub fn gini(data: &[u64]) -> f32 {
+pub fn gini<T: Unsigned + ToPrimitive>(data: &[T]) -> f32 {
     if data.len() == 0 {
         return 1.0;
     } 
@@ -19,8 +22,8 @@ pub fn gini(data: &[u64]) -> f32 {
     }
     let len = data.len() as f32;
     let mut count = HashMap::new();
-    for &value in data {
-        *count.entry(value).or_insert(0) += 1;
+    for ref value in data {
+        *count.entry(value.to_usize().unwrap()).or_insert(0) += 1;
     }
     let counts: Vec<usize> = count.into_iter().map(|(_, c)| c).collect();
     let indiv : Vec<f32> = counts.iter().map(|x| p_squared(*x, len)).collect();
@@ -276,16 +279,17 @@ pub fn jaccard_similiarity_score(pred: &[u64], actual: &[u64]) -> f32 {
 }
 
 
+
 #[cfg(test)]
 mod tests {
     use super::*;
     #[test]
     fn test_gini() {
-        let vec = vec![0, 0, 0, 1];
+        let vec : Vec<usize> = vec![0, 0, 0, 1];
         assert_eq!(0.375, gini(&vec));
-        let v2 = vec![0, 0];
+        let v2 : Vec<usize> = vec![0, 0];
         assert_eq!(0.0, gini(&v2));
-        let mut v3 = vec![0];
+        let mut v3: Vec<usize> = vec![0];
         v3.pop();
         assert_eq!(1.0, gini(&v3));
     }


### PR DESCRIPTION
This adds generic parameters to all of the functions included in Parsnip. 

It adds a dependency to the `num` crate, and makes the type for most functions `T: Unsigned + ToPrimitive + Ord + Clone`, in some cases, only  `T: Unsigned + ToPrimitive`.

There are also a few cases where there was a call to `.map()` followed by `.filter()` that could be simplified to `.filter()` and this improvement was made while changing the types.