### PR TITLE
Use approximate equality checks in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ is-it-maintained-open-issues = { repository = "ErikPartridge/parsnip" }
 travis-ci = { repository = "ErikPartridge/parsnip", branch = "master" }
 
 [dependencies]
+
+[dev-dependencies]
+approx = "0.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ where
 /// Supports macro and weighted averages
 /// ```
 /// # extern crate parsnip;
-/// #[macro_use] extern crate approx;
+/// #[macro_use] extern crate approx; // for approximate equality check
 /// use parsnip::precision;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];
@@ -198,7 +198,7 @@ where
 /// Supports macro and weighted averages
 /// ```
 /// # extern crate parsnip;
-/// #[macro_use] extern crate approx;
+/// #[macro_use] extern crate approx; // for approximate equality check
 /// use parsnip::recall;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];
@@ -248,7 +248,7 @@ where
 /// Supports macro and weighted averages
 /// ```
 /// # extern crate parsnip;
-/// #[macro_use] extern crate approx;
+/// #[macro_use] extern crate approx; // for approximate equality check
 /// use parsnip::f1_score;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];
@@ -323,7 +323,7 @@ where
 /// Supports macro and weighted averages
 /// ```
 /// # extern crate parsnip;
-/// #[macro_use] extern crate approx;
+/// #[macro_use] extern crate approx; // for approximate equality check
 /// use parsnip::fbeta_score;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,12 +116,14 @@ where
 ///
 /// Supports macro and weighted averages
 /// ```
+/// # extern crate parsnip;
+/// #[macro_use] extern crate approx;
 /// use parsnip::precision;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
-///
-/// assert_eq!(precision(&pred, &actual, Some("macro".to_string())), 0.22222222);
+/// 
+/// assert_ulps_eq!(precision(&pred, &actual, Some("macro".to_string())), 0.22222222);
 /// ```
 pub fn precision<T>(pred: &[T], actual: &[T], average: Option<String>) -> f32
 where
@@ -195,12 +197,14 @@ where
 ///
 /// Supports macro and weighted averages
 /// ```
+/// # extern crate parsnip;
+/// #[macro_use] extern crate approx;
 /// use parsnip::recall;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
-///
-/// assert_eq!(recall(&pred, &actual, Some("macro".to_string())), 0.333333334);
+/// 
+/// assert_ulps_eq!(recall(&pred, &actual, Some("macro".to_string())), 0.333333333);
 /// ```
 pub fn recall<T>(pred: &[T], actual: &[T], average: Option<String>) -> f32
 where
@@ -243,13 +247,15 @@ where
 ///
 /// Supports macro and weighted averages
 /// ```
+/// # extern crate parsnip;
+/// #[macro_use] extern crate approx;
 /// use parsnip::f1_score;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
-///
-/// assert_eq!(f1_score(&pred, &actual, Some("macro".to_string())), 0.26666665);
-/// assert_eq!(f1_score(&pred, &actual, Some("weighted".to_string())), 0.26666668);
+/// 
+/// assert_ulps_eq!(f1_score(&pred, &actual, Some("macro".to_string())), 0.26666666);
+/// assert_ulps_eq!(f1_score(&pred, &actual, Some("weighted".to_string())), 0.26666666);
 /// ```
 pub fn f1_score<T>(pred: &[T], actual: &[T], average: Option<String>) -> f32
 where
@@ -316,13 +322,15 @@ where
 ///
 /// Supports macro and weighted averages
 /// ```
+/// # extern crate parsnip;
+/// #[macro_use] extern crate approx;
 /// use parsnip::fbeta_score;
 ///
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
-///
-/// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("macro".to_string())), 0.23809524);
-/// assert_eq!(fbeta_score(&pred, &actual, 0.5, Some("weighted".to_string())), 0.23809527);
+/// 
+/// assert_ulps_eq!(fbeta_score(&pred, &actual, 0.5, Some("macro".to_string())), 0.23809524);
+/// assert_ulps_eq!(fbeta_score(&pred, &actual, 0.5, Some("weighted".to_string())), 0.23809527);
 /// ```
 pub fn fbeta_score<T>(pred: &[T], actual: &[T], beta: f32, average: Option<String>) -> f32
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -360,75 +360,75 @@ where
 }
 
 #[cfg(test)]
+#[macro_use] extern crate approx;
+
+#[cfg(test)]
 mod tests {
     use super::*;
     #[test]
     fn test_gini() {
         let vec = vec![0, 0, 0, 1];
-        assert_eq!(0.375, gini(&vec));
+        assert_ulps_eq!(0.375, gini(&vec));
         let v2 = vec![0, 0];
-        assert_eq!(0.0, gini(&v2));
+        assert_ulps_eq!(0.0, gini(&v2));
         let mut v3 = vec![0];
         v3.pop();
-        assert_eq!(1.0, gini(&v3));
+        assert_ulps_eq!(1.0, gini(&v3));
     }
 
     #[test]
     fn test_categorical_accuracy() {
         let pred = vec![0, 1, 0, 1, 0, 1];
         let real = vec![0, 0, 0, 0, 1, 0];
-        assert_eq!(0.33333334, categorical_accuracy(&pred, &real));
+        assert_ulps_eq!(0.33333333, categorical_accuracy(&pred, &real));
     }
 
     #[test]
     fn test_class_precision() {
         let actual = vec![0, 1, 2, 0, 1, 2];
         let pred = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(0.6666667, class_precision(&pred, &actual, &0));
+        assert_ulps_eq!(0.6666666, class_precision(&pred, &actual, &0));
     }
 
     #[test]
     fn test_class_recall() {
         let actual = vec![0, 1, 2, 0, 0, 0];
         let pred = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(0.75, class_recall(&pred, &actual, &0));
+        assert_ulps_eq!(0.75, class_recall(&pred, &actual, &0));
     }
 
     #[test]
     fn test_weighted_precision() {
         let actual = vec![0, 1, 2, 0, 1, 2];
         let pred = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(0.22222224, weighted_precision(&pred, &actual));
+        assert_ulps_eq!(0.22222222, weighted_precision(&pred, &actual));
     }
 
     #[test]
     fn test_macro_precision() {
         let actual = vec![0, 1, 2, 0, 1, 2];
         let pred = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(0.22222222, macro_precision(&pred, &actual));
+        assert_ulps_eq!(0.22222222, macro_precision(&pred, &actual));
     }
 
     #[test]
     fn test_macro_recall() {
         let actual = vec![0, 1, 2, 0, 1, 2];
         let pred = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(0.33333334, macro_recall(&pred, &actual));
+        assert_ulps_eq!(0.33333333, macro_recall(&pred, &actual));
     }
 
     #[test]
     fn test_weighted_recall() {
         let actual = vec![0, 1, 2, 0, 1, 2];
         let pred = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(0.333333334, weighted_recall(&pred, &actual));
+        assert_ulps_eq!(0.333333333, weighted_recall(&pred, &actual));
     }
 
     #[test]
     fn test_f1_score() {
         let actual = vec![0, 1, 2, 0, 1, 2];
         let pred = vec![0, 2, 1, 0, 0, 1];
-        assert_eq!(
-            f1_score(&pred, &actual, Some("macro".to_string())),
-            0.26666665
-        );
+        assert_ulps_eq!(f1_score(&pred, &actual, Some("macro".to_string())), 0.26666666);
     }
 }


### PR DESCRIPTION
`assert_eq!` is not very suitable for testing floating point numbers, as they can easily be off by a precision bit or so. The `approx` crate provides better alternatives, which have been used here. Note how we no longer need to guess the final digit of the intended outcome. In the future, we might want to simplify the existing doctests, since I had to make `extern crate approx;` visible for clarity. This is something to keep in mind when writing the root documentation.