### PR TITLE
Good errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
+use std::error::Error;  
 use std::fmt;
 
 /// The error returned when the length of the predicted and the ground truth do not match

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ impl fmt::Display for LengthError {
 
 impl Error for LengthError {
     fn description(&self) -> &str {
-        "Dataset lengths are do not match"
+        "Dataset lengths do not match"
     } 
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,13 +11,13 @@ pub struct LengthError(usize, usize);
 
 impl fmt::Display for LengthError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "The lengths of the predicted and actual datasets must be equal.\nInstead, the predicted length was found to be {} while the ground truth was found to be {}", self.0, self.1)
+        write!(f, "Dataset lengths must be equal, found {} and {}", self.0, self.1)
     }
 }
 
 impl Error for LengthError {
     fn description(&self) -> &str {
-        "The lengths of the predicted and actual datasets must be equal."
+        "Dataset lengths are do not match"
     } 
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,21 +93,23 @@ where
         .sum()
 }
 
-fn macro_precision<T>(pred: &[T], actual: &[T]) -> f32
+fn macro_precision<T>(pred: &[T], actual: &[T]) -> Result<f32, String>
 where
     T: Eq,
     T: Hash,
 {
-    assert_eq!(pred.len(), actual.len());
+    if pred.len() != actual.len() {
+        return Err("Array lengths do not match.".to_string());
+    }
     let classes: HashSet<_> = pred.into_iter().collect();
     let mut class_weights = HashMap::new();
     for value in classes.clone() {
         class_weights.insert(value, 1.0 / actual.len() as f32);
     }
-    classes
+    Ok(classes
         .iter()
         .map(|c| class_precision(pred, actual, c) / classes.len() as f32)
-        .sum()
+        .sum())
 }
 
 /// The precision of a dataset
@@ -123,7 +125,7 @@ where
 ///
 /// assert_eq!(precision(&pred, &actual, Some("macro".to_string())), 0.22222222);
 /// ```
-pub fn precision<T>(pred: &[T], actual: &[T], average: Option<String>) -> f32
+pub fn precision<T>(pred: &[T], actual: &[T], average: Option<String>) -> Result<f32, String>
 where
     T: Eq,
     T: Hash,
@@ -132,7 +134,7 @@ where
         None => macro_precision(pred, actual),
         Some(string) => match string.as_ref() {
             "macro" => macro_precision(pred, actual),
-            "weighted" => weighted_precision(pred, actual),
+            "weighted" => Ok(weighted_precision(pred, actual)),
             _ => panic!("invalid averaging type"),
         },
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,11 +338,8 @@ pub fn hamming_loss<T>(pred: &[T], actual: &[T]) -> Result<f32, LengthError>
 where
     T: Eq,
 {
-    let cat_acc = categorical_accuracy(pred, actual);
-    match cat_acc {
-        Ok(x) => Ok(1.0 - x),
-        err => err
-    }
+    let cat_acc = categorical_accuracy(pred, actual)?;
+    Ok(1. - cat_acc)
 }
 
 fn macro_fbeta_score<T>(pred: &[T], actual: &[T], beta: f32) -> f32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,21 +93,23 @@ where
         .sum()
 }
 
-fn macro_precision<T>(pred: &[T], actual: &[T]) -> f32
+fn macro_precision<T>(pred: &[T], actual: &[T]) -> Result<f32, String>
 where
     T: Eq,
     T: Hash,
 {
-    assert_eq!(pred.len(), actual.len());
+    if pred.len() != actual.len() {
+        return Err("Array lengths do not match.".to_string());
+    }
     let classes: HashSet<_> = pred.into_iter().collect();
     let mut class_weights = HashMap::new();
     for value in classes.clone() {
         class_weights.insert(value, 1.0 / actual.len() as f32);
     }
-    classes
+    Ok(classes
         .iter()
         .map(|c| class_precision(pred, actual, c) / classes.len() as f32)
-        .sum()
+        .sum())
 }
 
 /// The type of score averaging strategy employed in the calculation of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
-use std::error::Error;
 use std::fmt;
 
 /// The error returned when the length of the predicted and the ground truth do not match
@@ -74,7 +73,7 @@ where
     T: Eq,
 {
     if pred.len() != actual.len(){
-        return Err(Box::new(LengthError(pred.len(), actual.len())));
+        return Err(LengthError(pred.len(), actual.len()));
     }
     let truthy = pred.iter().zip(actual).filter(|(x, y)| x == y).count();
     Ok(truthy as f32 / pred.len() as f32)
@@ -175,7 +174,7 @@ where
     T: Hash,
 {
     if pred.len() != actual.len(){
-        return Err(Box::new(LengthError(pred.len(), actual.len())));
+        return Err(LengthError(pred.len(), actual.len()));
     }
     match average {
         Average::Macro => Ok(macro_precision(pred, actual)),
@@ -255,7 +254,7 @@ where
     T: Hash,
 {
     if pred.len() != actual.len(){
-        return Err(Box::new(LengthError(pred.len(), actual.len())));
+        return Err(LengthError(pred.len(), actual.len()));
     }
 
     match average {
@@ -309,7 +308,7 @@ where
     T: Hash,
 {
     if pred.len() != actual.len() {
-        return Err(Box::new(LengthError(pred.len(), actual.len())));
+        return Err(LengthError(pred.len(), actual.len()));
     }
     match average {
         Average::Macro => Ok(macro_f1(pred, actual)),
@@ -393,7 +392,7 @@ where
     T: Hash,
 {
     if pred.len() != actual.len(){
-        return Err(Box::new(LengthError(pred.len(), actual.len())));
+        return Err(LengthError(pred.len(), actual.len()));
     }
 
     match average {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,28 @@
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::hash::Hash;
+use std::error::Error;
+use std::fmt;
+
+#[derive(Debug)]
+struct LengthError;
+
+impl fmt::Display for LengthError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "The lengths of the predicted and actual datasets must be equal.")
+    }
+}
+
+impl Error for LengthError {
+    fn description(&self) -> &str {
+        "The lengths of the predicted and actual datasets must be equal."
+    } 
+
+    fn cause(&self) -> Option<&Error> {
+        None
+    }
+}
+
 
 /// Compute the gini impurity of a dataset.
 ///
@@ -93,13 +115,13 @@ where
         .sum()
 }
 
-fn macro_precision<T>(pred: &[T], actual: &[T]) -> Result<f32, String>
+fn macro_precision<T>(pred: &[T], actual: &[T]) -> Result<f32, LengthError>
 where
     T: Eq,
     T: Hash,
 {
     if pred.len() != actual.len() {
-        return Err("Array lengths do not match.".to_string());
+        return Err(LengthError);
     }
     let classes: HashSet<_> = pred.into_iter().collect();
     let mut class_weights = HashMap::new();
@@ -125,7 +147,7 @@ where
 ///
 /// assert_eq!(precision(&pred, &actual, Some("macro".to_string())), 0.22222222);
 /// ```
-pub fn precision<T>(pred: &[T], actual: &[T], average: Option<String>) -> Result<f32, String>
+pub fn precision<T>(pred: &[T], actual: &[T], average: Option<String>) -> Result<f32, LengthError>
 where
     T: Eq,
     T: Hash,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,15 +61,15 @@ where
 /// Returns a float where 1.0 is a perfectly accurate dataset
 /// ```
 /// use parsnip::categorical_accuracy;
-/// # use std::error::Error;
-/// # fn main() -> Result<(), Box<Error>> {
+/// # use parsnip::LengthError;
+/// # fn main() -> Result<(), LengthError> {
 /// let pred = vec![0, 0, 0 , 1, 2];
 /// let actual = vec![1, 1, 1, 1, 2];
 /// assert_eq!(categorical_accuracy(&pred, &actual)?, 0.4);
 /// # Ok(())
 /// # }
 /// ```
-pub fn categorical_accuracy<T>(pred: &[T], actual: &[T]) -> Result<f32, Box<Error>>
+pub fn categorical_accuracy<T>(pred: &[T], actual: &[T]) -> Result<f32, LengthError>
 where
     T: Eq,
 {
@@ -160,8 +160,8 @@ impl Default for Average {
 /// # extern crate parsnip;
 /// #[macro_use] extern crate approx; // for approximate equality check
 /// use parsnip::{Average, precision};
-/// # use std::error::Error;
-/// # fn main() -> Result<(), Box<Error>> {
+/// # use parsnip::LengthError;
+/// # fn main() -> Result<(), LengthError> {
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
 /// 
@@ -169,7 +169,7 @@ impl Default for Average {
 /// # Ok(())
 /// # }
 /// ```
-pub fn precision<T>(pred: &[T], actual: &[T], average: Average) -> Result<f32, Box<Error>>
+pub fn precision<T>(pred: &[T], actual: &[T], average: Average) -> Result<f32, LengthError>
 where
     T: Eq,
     T: Hash,
@@ -240,8 +240,8 @@ where
 /// # extern crate parsnip;
 /// #[macro_use] extern crate approx; // for approximate equality check
 /// use parsnip::{Average, recall};
-/// # use std::error::Error;
-/// # fn main() -> Result<(), Box<Error>> {
+/// # use parsnip::LengthError;
+/// # fn main() -> Result<(), LengthError> {
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
 /// 
@@ -249,7 +249,7 @@ where
 /// # Ok(())
 /// # }
 /// ```
-pub fn recall<T>(pred: &[T], actual: &[T], average: Average) -> Result<f32, Box<Error>>
+pub fn recall<T>(pred: &[T], actual: &[T], average: Average) -> Result<f32, LengthError>
 where
     T: Eq,
     T: Hash,
@@ -293,8 +293,8 @@ where
 /// # extern crate parsnip;
 /// #[macro_use] extern crate approx; // for approximate equality check
 /// use parsnip::{Average, f1_score};
-/// # use std::error::Error;
-/// # fn main() -> Result<(), Box<Error>> {
+/// # use parsnip::LengthError;
+/// # fn main() -> Result<(), LengthError> {
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
 /// 
@@ -303,7 +303,7 @@ where
 /// # Ok(())
 /// # }
 /// ```
-pub fn f1_score<T>(pred: &[T], actual: &[T], average: Average) -> Result<f32, Box<Error>>
+pub fn f1_score<T>(pred: &[T], actual: &[T], average: Average) -> Result<f32, LengthError>
 where
     T: Eq,
     T: Hash,
@@ -325,8 +325,8 @@ where
 /// ```
 /// use parsnip::hamming_loss;
 ///
-/// # use std::error::Error;
-/// # fn main() -> Result<(), Box<Error>> {
+/// # use parsnip::LengthError;
+/// # fn main() -> Result<(), LengthError> {
 /// let actual = vec![0, 1, 2, 0, 0];
 /// let pred = vec![0, 2, 1, 0, 1];
 ///
@@ -334,7 +334,7 @@ where
 /// # Ok(())
 /// # }
 /// ```
-pub fn hamming_loss<T>(pred: &[T], actual: &[T]) -> Result<f32, Box<Error>>
+pub fn hamming_loss<T>(pred: &[T], actual: &[T]) -> Result<f32, LengthError>
 where
     T: Eq,
 {
@@ -377,9 +377,8 @@ where
 /// ```
 /// # extern crate parsnip;
 /// #[macro_use] extern crate approx; // for approximate equality check
-/// use parsnip::{Average, fbeta_score};
-/// # use std::error::Error;
-/// # fn main() -> Result<(), Box<Error>> {
+/// use parsnip::{Average, fbeta_score, LengthError};
+/// # fn main() -> Result<(), LengthError> {
 /// let actual = vec![0, 1, 2, 0, 1, 2];
 /// let pred = vec![0, 2, 1, 0, 0, 1];
 /// 
@@ -388,7 +387,7 @@ where
 /// # Ok(())
 /// # }
 /// ```
-pub fn fbeta_score<T>(pred: &[T], actual: &[T], beta: f32, average: Average) -> Result<f32, Box<Error>>
+pub fn fbeta_score<T>(pred: &[T], actual: &[T], beta: f32, average: Average) -> Result<f32, LengthError>
 where
     T: Eq,
     T: Hash,
@@ -410,8 +409,8 @@ where
 /// Supports macro and weighted averages
 /// ```
 /// use parsnip::jaccard_similiarity_score;
-/// # use std::error::Error;
-/// # fn main() -> Result<(), Box<Error>> {
+/// # use parsnip::LengthError;
+/// # fn main() -> Result<(), LengthError> {
 /// let actual = vec![0, 2, 1, 3];
 /// let pred = vec![0, 1, 2, 3];
 ///
@@ -419,7 +418,7 @@ where
 /// # Ok(())
 /// # }
 /// ```
-pub fn jaccard_similiarity_score<T>(pred: &[T], actual: &[T]) -> Result<f32, Box<Error>>
+pub fn jaccard_similiarity_score<T>(pred: &[T], actual: &[T]) -> Result<f32, LengthError>
 where
     T: Eq,
 {


### PR DESCRIPTION
This implements the use of `Result<f32, LengthError>` for all public functions

Effectively, whenever any of the top-level functions are called, a check is done on the arrays, and they may return a `LengthError` if `actual.len()` and `pred.len()` differ.

The goal of this is to not panic when receiving different lengths and instead let the user handle it. This is in relation to #7 

Doc tests and unit tests were also updated to reflect this—doc tests primarily using `.unwrap()`. The error criteria also has unit tests.